### PR TITLE
feat(message-broker): Add Helm Chart for Message Broker

### DIFF
--- a/flame/Chart.yaml
+++ b/flame/Chart.yaml
@@ -39,3 +39,6 @@ dependencies:
   - name: flame-node-pod-orchestration
     repository: file://../node-pod-orchestration/helm/node-pod-orchestration
     version: 0.1.0
+  - name: flame-node-message-broker
+    repository: file://../node-message-broker/helm
+    version: 0.1.0

--- a/flame/values.yaml
+++ b/flame/values.yaml
@@ -117,3 +117,15 @@ node-pod-orchestration:
     POSTGRES_DB: postgres_db
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: postgres
+
+flame-node-message-broker:
+  # Uncomment, if you want to use a specific storage class.
+  # Otherwise, the default one will be used.
+  # common:
+  #   storageClassName: yourStorageClassToBeUsed
+  broker:
+    AUTH_JWKS_URL: http://keycloak-service:8080/realms/flame/protocol/openid-connect/certs
+    HUB_BASE_URL: https://api.privateaim.net/
+    HUB_AUTH_BASE_URL: https://auth.privateaim.net/
+    HUB_AUTH_ROBOT_ID: yourRobotId
+    HUB_AUTH_ROBOT_SECRET: yourRobotSecret

--- a/node-message-broker/helm/Chart.yaml
+++ b/node-message-broker/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: flame-node-message-broker
+description: A Helm chart for the FLAME message broker
+
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/node-message-broker/helm/templates/node-message-broker-db-service.yml
+++ b/node-message-broker/helm/templates/node-message-broker-db-service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-node-message-broker-db
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: flame
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  ports:
+    - port: 27017
+      targetPort: 27017

--- a/node-message-broker/helm/templates/node-message-broker-db-statefulset.yml
+++ b/node-message-broker/helm/templates/node-message-broker-db-statefulset.yml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-node-message-broker-db
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: flame
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  serviceName: {{ .Release.Name }}-node-message-broker-db
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: flame
+      app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: flame
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    spec:
+      restartPolicy: "Always"
+      containers:
+        - name: {{ .Release.Name }}-node-message-broker-db
+          image: mongo:7.0.5@sha256:fcde2d71bf00b592c9cabab1d7d01defde37d69b3d788c53c3bc7431b6b15de8
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: 27017
+          env:
+            - name: MONGO_INITDB_DATABASE
+              value: "message-broker"
+            - name: TZ
+              value: {{ .Values.common.timezone | default "Europe/Berlin" | quote }}
+          resources:
+            requests:
+              memory: "256Mi"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+          readinessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - 'db.runCommand("ping").ok'
+                - --quiet
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 15
+            initialDelaySeconds: 30
+          livenessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - 'db.runCommand("ping").ok'
+                - --quiet
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 15
+          volumeMounts:
+            - name: storage
+              mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes: ["ReadWriteMany"]
+        {{- if .Values.common.storageClassName }}
+        # Only use this if a storage class name is defined. Otherwise, use the default one within the cluster.
+        storageClassName: {{ .Values.common.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ (.Values.broker_db).storageSizeMi | default 100 }}Mi

--- a/node-message-broker/helm/templates/node-message-broker-deployment.yml
+++ b/node-message-broker/helm/templates/node-message-broker-deployment.yml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: "Always"
       containers:
         - name: {{ .Release.Name }}-node-message-broker
-          image: docker.io/flame/node-message-broker:{{ .Chart.AppVersion }}
+          image: ghcr.io/privateaim/node-message-broker:{{ .Chart.AppVersion }}
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/node-message-broker/helm/templates/node-message-broker-deployment.yml
+++ b/node-message-broker/helm/templates/node-message-broker-deployment.yml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-node-message-broker
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: flame
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+      app.kubernetes.io/component: server
+      app.kubernetes.io/part-of: flame
+      app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+        app.kubernetes.io/component: server
+        app.kubernetes.io/part-of: flame
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    spec:
+      restartPolicy: "Always"
+      containers:
+        - name: {{ .Release.Name }}-node-message-broker
+          image: docker.io/flame/node-message-broker:{{ .Chart.AppVersion }}
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SERVER_PORT
+              value: "8080"
+            - name: AUTH_JWKS_URL
+              value: {{ required "A valid JWKS URL for Keycloak is required." .Values.broker.AUTH_JWKS_URL }}
+            - name: MONGO_DB_URL
+              value: "mongodb://{{ .Release.Name}}-node-message-broker-db:27017"
+            - name: MONGO_DB_NAME
+              value: "message-broker"
+            - name: HUB_BASE_URL
+              value: {{ required "A valid HUB API base URL is required." .Values.broker.HUB_BASE_URL | default "https://api.privateaim.net/" | quote}}
+            - name: HUB_AUTH_BASE_URL
+              value: {{ required "A valid HUB Auth base URL is required." .Values.broker.HUB_AUTH_BASE_URL | default "https://auth.privateaim.net/" | quote }}
+            - name: HUB_AUTH_ROBOT_ID
+              value: {{ required "A robot ID associated with HUB Auth is required." .Values.broker.HUB_AUTH_ROBOT_ID | quote}}
+            - name: HUB_AUTH_ROBOT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hub-auth
+                  key: robot-secret
+            # DO NOT USE THIS IN PRODUCTION!!! This is just for internal testing purposes.
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: "0"
+          resources:
+            requests:
+              memory: "256Mi"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: "/health"
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 10

--- a/node-message-broker/helm/templates/node-message-broker-deployment.yml
+++ b/node-message-broker/helm/templates/node-message-broker-deployment.yml
@@ -52,7 +52,7 @@ spec:
             - name: HUB_AUTH_ROBOT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: hub-auth
+                  name: {{ .Release.Name}}-node-message-broker-hub-auth
                   key: robot-secret
             # DO NOT USE THIS IN PRODUCTION!!! This is just for internal testing purposes.
             - name: NODE_TLS_REJECT_UNAUTHORIZED

--- a/node-message-broker/helm/templates/node-message-broker-hub-auth-secret.yml
+++ b/node-message-broker/helm/templates/node-message-broker-hub-auth-secret.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name}}-node-message-broker-hub-auth
+data:
+  robot-secret: {{ required "A secret associated with the HUB Auth robot id .Values.broker.HUB_AUTH_ROBOT_ID is required." .Values.broker.HUB_AUTH_ROBOT_SECRET | b64enc }}

--- a/node-message-broker/helm/templates/node-message-broker-service.yml
+++ b/node-message-broker/helm/templates/node-message-broker-service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-node-message-broker
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: flame
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/node-message-broker/helm/values.yaml
+++ b/node-message-broker/helm/values.yaml
@@ -1,0 +1,12 @@
+common:
+  timezone: Europe/Berlin
+  storageClassName:
+broker:
+  AUTH_JWKS_URL:
+  HUB_BASE_URL: https://api.privateaim.net/
+  HUB_AUTH_BASE_URL: https://auth.privateaim.net/
+  HUB_AUTH_ROBOT_ID:
+  HUB_AUTH_ROBOT_SECRET:
+broker_db:
+  storageSizeMi:
+


### PR DESCRIPTION
Resolves #3.

Adds a basic helm chart for the node message broker. This does not yet include the integration into other components of the deployment. Also lacks a proper
readme at the moment.

/do-not-merge /wip