### PR TITLE
17 expose keycloak via ingress

### DIFF
--- a/flame/templates/flame-keycloak-realm-configmap.yaml
+++ b/flame/templates/flame-keycloak-realm-configmap.yaml
@@ -35,9 +35,8 @@ data:
       name: "Node UI"
       clientAuthenticatorType: "client-secret"
       secret: {{ include "ui.keycloak.clientSecret" (index .Subcharts "flame-node-ui") | b64dec }}
-      baseUrl: "http://localhost:3000"
-      redirectUris: [ "http://localhost:3000/auth/keycloak/callback" ]
-      webOrigins: [ "http://localhost:3000" ]
+      redirectUris: [ {{ printf "%s/*" (include "ui.ingress.hostname" (index .Subcharts "flame-node-ui")) }} ]
+      webOrigins: [ "+" ]
       standardFlowEnabled: true
       implicitFlowEnabled: false
       directAccessGrantsEnabled: true

--- a/flame/values.yaml
+++ b/flame/values.yaml
@@ -220,7 +220,15 @@ keycloak:
 flame-node-hub-adapter:
   ## For defining ingress specific metadata
   ingress:
-    domain: localhost
+    ## @param ingress.enabled Enable ingress record generation for the Hub Adapter
+    ##
+    enabled: false
+    ## @param ingress.pathType Ingress path type
+    ##
+    pathType: ImplementationSpecific
+    ## @param ingress.hostname Default host for the ingress record (evaluated as template)
+    ##
+    hostname: ""
 
   ## Keycloak related information
   idp:
@@ -329,7 +337,21 @@ flame-node-message-broker:
 
 flame-node-ui:
   env: development
-  url: http://localhost:3000
+
+  ## For defining ingress specific metadata
+  ingress:
+    ## @param ingress.enabled Enable ingress record generation for the Node UI
+    ##
+    enabled: false
+    ## @param ingress.pathType Ingress path type
+    ##
+    pathType: ImplementationSpecific
+    ## @param ingress.hostname Default host for the ingress record (evaluated as template)
+    ##
+    hostname: "http://localhost"
+    ## @param ingress.path Default file path for the ingress hostname
+    ##
+    path: "/"
 
   ## Keycloak related information
   idp:

--- a/flame/values.yaml
+++ b/flame/values.yaml
@@ -10,12 +10,6 @@ global:
       realmId: ""
       robotUser: ""
       robotSecret: ""
-  node:
-    ingress:
-      ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
-      enabled: false
-      ## @param global.node.ingress.enabled Host name to be assigned to the Node UI (/) and Hub Adapter API (/api)
-      hostname: ""
 
 # kong values
 kong:
@@ -231,7 +225,7 @@ flame-node-hub-adapter:
     enabled: false
     ## @param ingress.pathType Ingress path type
     ##
-    pathType: Prefix
+    pathType: ImplementationSpecific
     ## @param ingress.hostname Default host for the ingress record (evaluated as template)
     ##
     hostname: ""

--- a/flame/values.yaml
+++ b/flame/values.yaml
@@ -10,6 +10,12 @@ global:
       realmId: ""
       robotUser: ""
       robotSecret: ""
+  node:
+    ingress:
+      ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
+      enabled: false
+      ## @param global.node.ingress.enabled Host name to be assigned to the Node UI (/) and Hub Adapter API (/api)
+      hostname: ""
 
 # kong values
 kong:
@@ -225,7 +231,7 @@ flame-node-hub-adapter:
     enabled: false
     ## @param ingress.pathType Ingress path type
     ##
-    pathType: ImplementationSpecific
+    pathType: Prefix
     ## @param ingress.hostname Default host for the ingress record (evaluated as template)
     ##
     hostname: ""

--- a/node-hub-api-adapter/helm/hub-adapter/templates/_helpers.tpl
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/_helpers.tpl
@@ -2,10 +2,21 @@
 Set the API's root path. If ingress is enabled, defaults to "/api" else remains blank
 */}}
 {{- define "adapter.root.path" -}}
-{{- if .Values.ingress.enabled -}}
+{{- if or .Values.global.node.ingress.enabled .Values.ingress.enabled -}}
     {{- print "/api" -}}
 {{- else -}}
     {{- print "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set the API's root path. If ingress is enabled, defaults to "/api" else remains blank
+*/}}
+{{- define "adapter.ingress.hostname" -}}
+{{- if .Values.global.node.ingress.hostname -}}
+    {{- .Values.global.node.ingress.hostname -}}
+{{- else -}}
+    {{- .Values.ingress.hostname -}}
 {{- end -}}
 {{- end -}}
 

--- a/node-hub-api-adapter/helm/hub-adapter/templates/_helpers.tpl
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/_helpers.tpl
@@ -1,4 +1,15 @@
 {{/*
+Set the API's root path. If ingress is enabled, defaults to "/api" else remains blank
+*/}}
+{{- define "adapter.root.path" -}}
+{{- if .Values.ingress.enabled -}}
+    {{- print "/api" -}}
+{{- else -}}
+    {{- print "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the secret containing the hub robot secret
 */}}
 {{- define "adapter.hub.secretName" -}}

--- a/node-hub-api-adapter/helm/hub-adapter/templates/_helpers.tpl
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/_helpers.tpl
@@ -2,21 +2,10 @@
 Set the API's root path. If ingress is enabled, defaults to "/api" else remains blank
 */}}
 {{- define "adapter.root.path" -}}
-{{- if or .Values.global.node.ingress.enabled .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled -}}
     {{- print "/api" -}}
 {{- else -}}
     {{- print "" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Set the API's root path. If ingress is enabled, defaults to "/api" else remains blank
-*/}}
-{{- define "adapter.ingress.hostname" -}}
-{{- if .Values.global.node.ingress.hostname -}}
-    {{- .Values.global.node.ingress.hostname -}}
-{{- else -}}
-    {{- .Values.ingress.hostname -}}
 {{- end -}}
 {{- end -}}
 

--- a/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-deployment.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-deployment.yaml
@@ -24,6 +24,8 @@ spec:
             - containerPort: 5000
               name: healthcp
           env:
+            - name: API_ROOT_PATH
+              value: {{ (include "adapter.root.path" .) | default "" }}
             - name: API_CLIENT_ID
               value: {{ .Values.idp.clientId | default "hub-adapter" | quote }}
             - name: API_CLIENT_SECRET

--- a/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-deployment.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: api-gateway
           image: ghcr.io/privateaim/node-hub-api-adapter:latest
-          imagePullPolicy: IfNotPresent  # Maybe "Always" during debug
+          imagePullPolicy: Always
           ports:
             - containerPort: 5000
               name: healthcp

--- a/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-ingress.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if or .Values.global.node.ingress.enabled .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,7 +11,7 @@ metadata:
     deployment-id:  {{ .Release.Name }}
 spec:
   rules:
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ regexReplaceAll "^https?://(.*)" (include "adapter.ingress.hostname" .) "${1}" }}
       http:
         paths:
           - path: /api(/|$)(.*)

--- a/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-ingress.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.global.node.ingress.enabled .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,7 +11,7 @@ metadata:
     deployment-id:  {{ .Release.Name }}
 spec:
   rules:
-    - host: {{ regexReplaceAll "^https?://(.*)" (include "adapter.ingress.hostname" .) "${1}" }}
+    - host: {{ .Values.ingress.hostname }}
       http:
         paths:
           - path: /api(/|$)(.*)

--- a/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-ingress.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/templates/hub-adapter-ingress.yaml
@@ -1,20 +1,24 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-hub-adapter-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
   labels:
     component: hub-adapter-service
     version: {{ .Chart.AppVersion }}
     deployment-id:  {{ .Release.Name }}
 spec:
   rules:
-    - host: {{ .Values.ingress.domain }}
+    - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          - path: /api(/|$)(.*)
+            pathType: {{ .Values.ingress.pathType }}
             backend:
               service:
                 name: {{ .Release.Name }}-hub-adapter-service
                 port:
                   number: 5000
+{{- end }}

--- a/node-hub-api-adapter/helm/hub-adapter/values.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/values.yaml
@@ -16,7 +16,15 @@ global:
 
 ## For defining ingress specific metadata
 ingress:
-  domain: localhost
+  ## @param ingress.enabled Enable ingress record generation for the Hub Adapter
+  ##
+  enabled: false
+  ## @param ingress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## @param ingress.hostname Default host for the ingress record (evaluated as template)
+  ##
+  hostname: ""
 
 ## Keycloak related information
 idp:

--- a/node-hub-api-adapter/helm/hub-adapter/values.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/values.yaml
@@ -13,6 +13,12 @@ global:
       robotUser: ""
       ## @param global.hub.auth.robotSecret Robot secret. Overrides hub.auth.robotSecret if provided
       robotSecret: ""
+  node:
+    ingress:
+      ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
+      enabled: false
+      ## @param global.node.ingress.enabled Host name to be assigned to the Node UI (/) and Hub Adapter API (/api)
+      hostname: ""
 
 ## For defining ingress specific metadata
 ingress:
@@ -21,7 +27,7 @@ ingress:
   enabled: false
   ## @param ingress.pathType Ingress path type
   ##
-  pathType: ImplementationSpecific
+  pathType: Prefix
   ## @param ingress.hostname Default host for the ingress record (evaluated as template)
   ##
   hostname: ""

--- a/node-hub-api-adapter/helm/hub-adapter/values.yaml
+++ b/node-hub-api-adapter/helm/hub-adapter/values.yaml
@@ -13,12 +13,6 @@ global:
       robotUser: ""
       ## @param global.hub.auth.robotSecret Robot secret. Overrides hub.auth.robotSecret if provided
       robotSecret: ""
-  node:
-    ingress:
-      ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
-      enabled: false
-      ## @param global.node.ingress.enabled Host name to be assigned to the Node UI (/) and Hub Adapter API (/api)
-      hostname: ""
 
 ## For defining ingress specific metadata
 ingress:
@@ -27,7 +21,7 @@ ingress:
   enabled: false
   ## @param ingress.pathType Ingress path type
   ##
-  pathType: Prefix
+  pathType: ImplementationSpecific
   ## @param ingress.hostname Default host for the ingress record (evaluated as template)
   ##
   hostname: ""

--- a/node-ui/helm/templates/_helpers.tpl
+++ b/node-ui/helm/templates/_helpers.tpl
@@ -52,9 +52,10 @@ Generate a random clientSecret value for the node-ui client in keycloak if none 
 Return the Keycloak endpoint
 */}}
 {{- define "ui.keycloak.endpoint" -}}
+{{- $realmSuffix := printf "/realms/%s" .Values.idp.realm -}}
 {{- if .Values.idp.host -}}
-    {{- .Values.idp.host -}}
+    {{- printf "http://%s%s" .Values.idp.host $realmSuffix -}}
 {{- else -}}
-    {{- printf "http://%s-keycloak" .Release.Name -}}
+    {{- printf "http://%s-keycloak%s" .Release.Name $realmSuffix -}}
 {{- end -}}
 {{- end -}}

--- a/node-ui/helm/templates/_helpers.tpl
+++ b/node-ui/helm/templates/_helpers.tpl
@@ -1,4 +1,32 @@
 {{/*
+Set the hostname of the Node UI
+*/}}
+{{- define "ui.ingress.hostname" -}}
+{{- if .Values.global.node.ingress.enabled -}}
+    {{- if .Values.global.node.ingress.hostname -}}
+        {{- .Values.global.node.ingress.hostname -}}
+    {{- else -}}
+        {{- .Values.ingress.hostname -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "http://localhost:3000" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the hub adapter endpoint
+*/}}
+{{- define "ui.adapter.endpoint" -}}
+{{- if .Values.node.adapter -}}
+    {{- .Values.node.adapter -}}
+{{- else if and .Values.global.node.ingress.enabled .Values.global.node.ingress.hostname -}}
+    {{- printf "%s/api" .Values.global.node.ingress.hostname -}}
+{{- else -}}
+    {{- printf "http://%s-hub-adapter-service:5000" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the secret containing the Keycloak client secret
 */}}
 {{- define "ui.keycloak.secretName" -}}

--- a/node-ui/helm/templates/_helpers.tpl
+++ b/node-ui/helm/templates/_helpers.tpl
@@ -9,7 +9,7 @@ Set the hostname of the Node UI
         {{- .Values.ingress.hostname -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "http://localhost:3000" .Release.Name -}}
+    {{- print "http://localhost:3000" -}}
 {{- end -}}
 {{- end -}}
 
@@ -22,7 +22,7 @@ Return the hub adapter endpoint
 {{- else if and .Values.global.node.ingress.enabled .Values.global.node.ingress.hostname -}}
     {{- printf "%s/api" .Values.global.node.ingress.hostname -}}
 {{- else -}}
-    {{- printf "http://%s-hub-adapter-service:5000" .Release.Name -}}
+    {{- print "http://localhost:5000" -}}
 {{- end -}}
 {{- end -}}
 

--- a/node-ui/helm/templates/node-ui-deployment.yaml
+++ b/node-ui/helm/templates/node-ui-deployment.yaml
@@ -23,16 +23,11 @@ spec:
           ports:
             - containerPort: 3000
               name: ui
-{{/*          readinessProbe:*/}}
-{{/*            initialDelaySeconds: 45*/}}
-{{/*            httpGet:*/}}
-{{/*              path: /healthz*/}}
-{{/*              port: healthcp*/}}
           env:
             - name: NODE_ENV
               value: {{ .Values.env | default "development" | quote }}
             - name: NUXT_PUBLIC_BASE_URL
-              value: {{ .Values.url | default "http://localhost:3000" | quote }}
+              value: {{ printf "http://%s" .Values.ingress.hostname | default "http://localhost:3000" | quote }}
             - name: NUXT_PUBLIC_HUB_ADAPTER_URL
               value: {{ .Values.node.adapter | default "http://localhost:5000" | quote }}
             - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_BASE_URL
@@ -40,20 +35,15 @@ spec:
             - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_ID
               value: {{ .Values.idp.clientId | default "node-ui" | quote }}
             - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "ui.keycloak.secretName" . }}
-                  key: {{ include "ui.keycloak.secretKey" . }}
+              value: QN2HeO2LeXMY10VrP4cf2x5JHTFInm4f
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: {{ include "ui.keycloak.secretName" . }}
+#                   key: {{ include "ui.keycloak.secretKey" . }}
             - name: NUXT_OIDC_TOKEN_KEY
-              value: {{ randAlphaNum 32 | b64enc }}
-            - name: NUXT_OIDC_SESSION_SECRET
-              value: {{ randAlphaNum 48 | quote }}
-            - name: NUXT_OIDC_AUTH_SESSION_SECRET
-              value: {{ randAlphaNum 48 | quote }}
-{{/*          livenessProbe:*/}}
-{{/*            httpGet:*/}}
-{{/*              path: /healthz*/}}
-{{/*              port: healthcp*/}}
-{{/*            failureThreshold: 3*/}}
-{{/*            periodSeconds: 60*/}}
-{{/*            initialDelaySeconds: 60*/}}
+              value: A2H9OFjRheZkXmigAAkNFdOuWg9JrsywN0EP6u+KneQ=
+#               value: {{ randAlphaNum 32 | b64enc }}
+#             - name: NUXT_OIDC_SESSION_SECRET
+#               value: {{ randAlphaNum 48 | quote }}
+#             - name: NUXT_OIDC_AUTH_SESSION_SECRET
+#               value: {{ randAlphaNum 48 | quote }}

--- a/node-ui/helm/templates/node-ui-deployment.yaml
+++ b/node-ui/helm/templates/node-ui-deployment.yaml
@@ -26,16 +26,24 @@ spec:
           env:
             - name: NODE_ENV
               value: {{ .Values.env | default "development" | quote }}
-            - name: NUXT_BASE_URL
-              value: {{ include "ui.ingress.hostname" . }}
-            - name: NUXT_HUB_ADAPTER_URL
-              value: {{ include "ui.adapter.endpoint" . }}
-            - name: NUXT_KEYCLOAK_BASE_URL
+            - name: NUXT_PUBLIC_BASE_URL
+              value: {{ printf "http://%s" .Values.ingress.hostname | default "http://localhost:3000" | quote }}
+            - name: NUXT_PUBLIC_HUB_ADAPTER_URL
+              value: {{ .Values.node.adapter | default "http://localhost:5000" | quote }}
+            - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_BASE_URL
               value: {{ include "ui.keycloak.endpoint" . }}
-            - name: NUXT_KEYCLOAK_CLIENT_ID
+            - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_ID
               value: {{ .Values.idp.clientId | default "node-ui" | quote }}
-            - name: NUXT_KEYCLOAK_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "ui.keycloak.secretName" . }}
-                  key: {{ include "ui.keycloak.secretKey" . }}
+            - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_SECRET
+              value: QN2HeO2LeXMY10VrP4cf2x5JHTFInm4f
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: {{ include "ui.keycloak.secretName" . }}
+#                   key: {{ include "ui.keycloak.secretKey" . }}
+            - name: NUXT_OIDC_TOKEN_KEY
+              value: A2H9OFjRheZkXmigAAkNFdOuWg9JrsywN0EP6u+KneQ=
+#               value: {{ randAlphaNum 32 | b64enc }}
+#             - name: NUXT_OIDC_SESSION_SECRET
+#               value: {{ randAlphaNum 48 | quote }}
+#             - name: NUXT_OIDC_AUTH_SESSION_SECRET
+#               value: {{ randAlphaNum 48 | quote }}

--- a/node-ui/helm/templates/node-ui-deployment.yaml
+++ b/node-ui/helm/templates/node-ui-deployment.yaml
@@ -26,24 +26,16 @@ spec:
           env:
             - name: NODE_ENV
               value: {{ .Values.env | default "development" | quote }}
-            - name: NUXT_PUBLIC_BASE_URL
-              value: {{ printf "http://%s" .Values.ingress.hostname | default "http://localhost:3000" | quote }}
-            - name: NUXT_PUBLIC_HUB_ADAPTER_URL
-              value: {{ .Values.node.adapter | default "http://localhost:5000" | quote }}
-            - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_BASE_URL
+            - name: NUXT_BASE_URL
+              value: {{ include "ui.ingress.hostname" . }}
+            - name: NUXT_HUB_ADAPTER_URL
+              value: {{ include "ui.adapter.endpoint" . }}
+            - name: NUXT_KEYCLOAK_BASE_URL
               value: {{ include "ui.keycloak.endpoint" . }}
-            - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_ID
+            - name: NUXT_KEYCLOAK_CLIENT_ID
               value: {{ .Values.idp.clientId | default "node-ui" | quote }}
-            - name: NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_SECRET
-              value: QN2HeO2LeXMY10VrP4cf2x5JHTFInm4f
-#               valueFrom:
-#                 secretKeyRef:
-#                   name: {{ include "ui.keycloak.secretName" . }}
-#                   key: {{ include "ui.keycloak.secretKey" . }}
-            - name: NUXT_OIDC_TOKEN_KEY
-              value: A2H9OFjRheZkXmigAAkNFdOuWg9JrsywN0EP6u+KneQ=
-#               value: {{ randAlphaNum 32 | b64enc }}
-#             - name: NUXT_OIDC_SESSION_SECRET
-#               value: {{ randAlphaNum 48 | quote }}
-#             - name: NUXT_OIDC_AUTH_SESSION_SECRET
-#               value: {{ randAlphaNum 48 | quote }}
+            - name: NUXT_KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ui.keycloak.secretName" . }}
+                  key: {{ include "ui.keycloak.secretKey" . }}

--- a/node-ui/helm/templates/node-ui-ingress.yaml
+++ b/node-ui/helm/templates/node-ui-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.global.node.ingress.enabled .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -9,7 +9,7 @@ metadata:
     deployment-id:  {{ .Release.Name }}
 spec:
   rules:
-    - host: {{ regexReplaceAll "^https?://(.*)" (include "ui.ingress.hostname" .) "${1}" }}
+    - host: {{ .Values.ingress.hostname }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}

--- a/node-ui/helm/templates/node-ui-ingress.yaml
+++ b/node-ui/helm/templates/node-ui-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -8,13 +9,14 @@ metadata:
     deployment-id:  {{ .Release.Name }}
 spec:
   rules:
-    - host: {{ .Values.ingress.domain }}
+    - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
             backend:
               service:
                 name: {{ .Release.Name }}-node-ui-service
                 port:
                   number: 3000
+{{- end }}

--- a/node-ui/helm/templates/node-ui-ingress.yaml
+++ b/node-ui/helm/templates/node-ui-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if or .Values.global.node.ingress.enabled .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -9,7 +9,7 @@ metadata:
     deployment-id:  {{ .Release.Name }}
 spec:
   rules:
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ regexReplaceAll "^https?://(.*)" (include "ui.ingress.hostname" .) "${1}" }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}

--- a/node-ui/helm/values.yaml
+++ b/node-ui/helm/values.yaml
@@ -1,12 +1,3 @@
-## Global variables
-global:
-  node:
-    ingress:
-      ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
-      enabled: false
-      ## @param global.node.ingress.enabled Host name to be assigned to the Node UI (/) and Hub Adapter API (/api)
-      hostname: ""
-
 env: development
 
 ## For defining ingress specific metadata
@@ -47,6 +38,5 @@ idp:
 
 ## Downstream node services
 node:
-  ## @param node.adapter Hub adapter endpoint.
-  ## This will overwrite the global.node.ingress.host generated path if provided!
+  ## @param node.adapter Hub adapter endpoint
   adapter: ""

--- a/node-ui/helm/values.yaml
+++ b/node-ui/helm/values.yaml
@@ -1,3 +1,12 @@
+## Global variables
+global:
+  node:
+    ingress:
+      ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
+      enabled: false
+      ## @param global.node.ingress.enabled Host name to be assigned to the Node UI (/) and Hub Adapter API (/api)
+      hostname: ""
+
 env: development
 
 ## For defining ingress specific metadata
@@ -38,5 +47,6 @@ idp:
 
 ## Downstream node services
 node:
-  ## @param node.adapter Hub adapter endpoint
+  ## @param node.adapter Hub adapter endpoint.
+  ## This will overwrite the global.node.ingress.host generated path if provided!
   adapter: ""

--- a/node-ui/helm/values.yaml
+++ b/node-ui/helm/values.yaml
@@ -1,9 +1,19 @@
+env: development
+
 ## For defining ingress specific metadata
 ingress:
-  domain: localhost
-
-env: development
-url: http://localhost:3000
+  ## @param ingress.enabled Enable ingress record generation for the Node UI
+  ##
+  enabled: false
+  ## @param ingress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## @param ingress.hostname Default host for the ingress record (evaluated as template)
+  ##
+  hostname: http://localhost
+  ## @param ingress.path Default file path for the ingress hostname
+  ##
+  path: "/"
 
 ## Keycloak related information
 idp:


### PR DESCRIPTION
Added options for providing domains (ingress) to the UI, hub adapter, and keycloak. Also simplified the required `my-values.yaml` that needs to be passed during helm installation/upgrading. Here is a template:

```yaml
global:
  hub:
    auth:
      robotUser: myRobotUsername
      robotSecret: xxx
  node:
    ingress:
      enabled: false
      # For the Node UI and Hub Adapter. If hostname is provided, then ingress.enabled needs to be set to "true"
      # If ingress enabled, the hub adapter API GUI will be made available at `/api/docs` e.g. https://mydomain.de/api/docs
      hostname: "" 

flame-node-pod-orchestration:
  env:
    RESULT_CLIENT_SECRET: xxx

flame-node-ui:
  idp:
    host: my.institution.keycloak.de

keycloak:
  ingress:
    enabled: true
    hostname: my.institution.keycloak.de
```