### PR TITLE
Feature/28 provision additional certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,18 @@ If you have a hostname that you'd like to use for your instance, change all inst
 file to your hostname. Be sure to leave the text (e.g. "https://") before and after "localhost" the same. Be sure this 
 hostname is properly configured in your DNS settings and your reverse proxy to point to your kubernetes cluster.
 
-### 3. Deploy the Flame Node
+### 3. Add Custom Certificates (optional)
+
+If the `node` is going to be deployed to an environment where outbound requests are intercepted for inspection by
+leveraging custom certificates then these certificates have to be provisioned for `node` components to pick them up for
+use.
+
+To do so, add any related certificate in `PEM` format to `flame/certs/` using `.pem` as the file extension.
+
+> [!IMPORTANT]  
+> Make sure that all certificates together are not larger than 1MB (due to k8s constraints)!
+
+### 4. Deploy the Flame Node
 Initial deployment will take some time (minutes) to pull of the images, execute the jobs, and to populate the containers. Please be patient during the installation process.
 
 Once you have your configured values YAML file, you can perform installation using helm:

--- a/flame/templates/additional-certs-configmap.yaml
+++ b/flame/templates/additional-certs-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flame-additional-certs
+data:
+  certs.pem: |
+{{- range $path, $_ :=  .Files.Glob  "certs/**.pem" }}
+{{ $.Files.Get $path | toString | trim | indent 4 -}}
+{{- end }}

--- a/node-message-broker/helm/templates/node-message-broker-deployment.yml
+++ b/node-message-broker/helm/templates/node-message-broker-deployment.yml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: "Always"
       containers:
         - name: {{ .Release.Name }}-node-message-broker
-          image: ghcr.io/privateaim/node-message-broker:{{ .Chart.AppVersion }}
+          image: "ghcr.io/privateaim/node-message-broker:{{ .Chart.AppVersion }}"
           imagePullPolicy: "Always"
           securityContext:
             runAsNonRoot: true
@@ -50,7 +50,7 @@ spec:
             - name: HUB_AUTH_BASE_URL
               value: {{ required "A valid HUB Auth base URL is required." (include "broker.hub.authApi" .) | default "https://auth.privateaim.net/" | quote }}
             - name: HUB_MESSENGER_BASE_URL
-              value: {{ required "A valid HUB Messenger base URL is required." (include "broker.hub.messengerApi" .) | default "https://messenger.privateaim.net/" | quote }}              
+              value: {{ required "A valid HUB Messenger base URL is required." (include "broker.hub.messengerApi" .) | default "https://messenger.privateaim.net/" | quote }}
             - name: HUB_AUTH_ROBOT_ID
               value: {{ required "A robot ID for the Hub is required." (include "broker.hub.robotUser" .) | quote }}
             - name: HUB_AUTH_ROBOT_SECRET
@@ -58,9 +58,15 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-node-message-broker-hub-auth
                   key: robot-secret
+            - name: NODE_EXTRA_CA_CERTS
+              value: "/mnt/certs/certs.pem"
             # DO NOT USE THIS IN PRODUCTION!!! This is just for internal testing purposes.
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"
+          volumeMounts:
+            - mountPath: "/mnt/certs/certs.pem"
+              name: additional-certs
+              subPath: "certs.pem"
           resources:
             requests:
               memory: "256Mi"
@@ -81,3 +87,7 @@ spec:
             initialDelaySeconds: 90
             periodSeconds: 10
             timeoutSeconds: 10
+      volumes:
+        - name: additional-certs
+          configMap:
+            name: flame-additional-certs


### PR DESCRIPTION
Adds a routine to provision custom certificates in PEM format. This is necessary when deploying the `node` to an environment where requests are being intercepted for inspection causing SSL termination by leveraging custom certificates (e.g. self-signed certificates).

Forwards these custom certificates to the `message broker` component. Without this change the component is not able to connect to the `hub` when deployed in an environment resembling the one described above.